### PR TITLE
Updates qx

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "CSSselect": "~0.3.0",
     "q-io": ">=1.1.0",
     "parserlib": ">0.2.0",
-    "qx": "~0.1.0"
+    "qx": "~0.2.4"
   },
   "devDependencies": {
     "commander": "~1.0.5",


### PR DESCRIPTION
Qx 0.1.0 had a major flaw : The file was named `qx.js` but in the package.json main file was set to `Qx.js` with a capital **Q**. It ran fine on Mac OS X which is case insensitive for this, but it breaks on linux because of this. 

This pullrequest solves this problem as it seems like you corrected Qx since then.

It does not seem to break anything although you did not document your testing process at all and could not spend too much time trying to figure out how to run them. 
