### PR TITLE
Q deprecated some things

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "q": ">=0.9.0",
+    "q": "^1.0.1",
     "cheerio": "~0.10.1",
     "winston": "~0.6.2",
     "lodash": "~1.0.0-rc.3",


### PR DESCRIPTION
Styliner only works with the 1x branch of Q. Quick fix is to just update the package.json file. Better fix is to make it 2x compatible.
