### PR TITLE
Upgrade Q related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "styliner",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Applies external CSS stylesheets to HTML emails to work with Gmail.",
-  "homepage": "https://github.com/SLaks/Styliner",
+  "homepage": "https://github.com/zamb3zi/Styliner",
   "author": "Schabse Laks <Dev@SLaks.net> (http://slaks.net)",
   "keywords": [
     "email",
@@ -12,7 +12,7 @@
   "main": "lib/Styliner.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/SLaks/Styliner.git"
+    "url": "git://github.com/zamb3zi/Styliner.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   },
   "license": "MIT",
   "dependencies": {
-    "q": "^1.0.1",
+    "q": "^1.4.1",
     "cheerio": "~0.10.1",
     "winston": "~0.6.2",
     "lodash": "~1.0.0-rc.3",
     "CSSselect": "~0.3.0",
-    "q-io": ">=2.0.6",
+    "q-io": "^1.13.2",
     "parserlib": ">0.2.0",
-    "qx": "~0.2.4"
+    "qx": "^1.0.0"
   },
   "devDependencies": {
     "commander": "~1.0.5",


### PR DESCRIPTION
Currently Styliner is failing due to deprecation in Q:
```isPromiseAlike is deprecated, use (not supported) instead. Error
at Function.Q_deprecate [as isPromiseAlike] (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/node_modules/q/q.js:166:21)
at eagerWhen (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/Qx.js:52:8)
at /home/cds/tcmweb/node_modules/styliner/node_modules/qx/Qx.js:61:11
at Array.map (native)
at /home/cds/tcmweb/node_modules/styliner/node_modules/qx/Qx.js:60:20
at Promise_then_fulfilled (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/node_modules/q/q.js:766:44)
at Promise_done_fulfilled (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/node_modules/q/q.js:835:31)
at Fulfilled_dispatch [as dispatch] (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/node_modules/q/q.js:1229:9)
at Promise_done_task (/home/cds/tcmweb/node_modules/styliner/node_modules/qx/node_modules/q/q.js:871:28)
at RawTask.call (/home/cds/tcmweb/node_modules/asap/asap.js:40:19)```

Upgrading to the latest versions resolves this problem.